### PR TITLE
Fix: correct reply handling in C# lab for run-prompts exercise

### DIFF
--- a/Instructions/Labs/02-run-prompts.md
+++ b/Instructions/Labs/02-run-prompts.md
@@ -201,8 +201,19 @@ Now you create a prompt template that instructs the AI to suggest suitable roles
         chatHistory,
         kernel: kernel
     );
-    Console.WriteLine("Assistant: " + reply.ToString());
-    chatHistory.AddAssistantMessage(reply.ToString());
+
+    var content = reply.FirstOrDefault()?.Content;
+
+    if (string.IsNullOrWhiteSpace(content))
+    {
+        Console.WriteLine("Assistant: [No reply]");
+    }
+    else
+    {
+        Console.WriteLine($"Assistant: {content}");
+
+        chatHistory.AddAssistantMessage(content);
+    }
     ```
 
     This code retrieves the reply from the LLM, outputs it to the console, and appends it to the chat history.


### PR DESCRIPTION
This update fixes incorrect reply handling in the C# version of the **Run prompts with Semantic Kernel** lab (`Instructions/Labs/02-run-prompts.md`).

### Summary of changes:

- Replaced `reply.ToString()` with `reply.FirstOrDefault()?.Content` to correctly extract the assistant's message.
- Added a null/empty check to avoid adding invalid messages to the chat history.
- Improved user feedback by displaying `[No reply]` when the response is blank.

These changes improve reliability, user experience, and maintain consistency with the Semantic Kernel SDK's expected usage.