### PR TITLE
LAB05 - Create Semantic Kernel plugin ex - step 02: The signature of AddAzureOpenAIChatCompletion method is changed

### DIFF
--- a/Instructions/Labs/05-create-semantic-kernel-ai-assistant.md
+++ b/Instructions/Labs/05-create-semantic-kernel-ai-assistant.md
@@ -150,7 +150,7 @@ Now that you deployed a model, you can use the Semantic Kernel SDK to create a c
      ```c#
     // Create a kernel builder with Azure OpenAI chat completion
     var builder = Kernel.CreateBuilder();
-    builder.AddAzureOpenAIChatCompletion(apiKey, endpoint, deploymentName);
+    builder.AddAzureOpenAIChatCompletion(deploymentName, endpoint, apiKey);
     var kernel = builder.Build();
     ```
 


### PR DESCRIPTION
This pull request includes a small change to the `Instructions/Labs/05-create-semantic-kernel-ai-assistant.md` file. The change updates the order of parameters in the `AddAzureOpenAIChatCompletion` method to match the expected order in the SDK.

According to the official documentation ([here](https://learn.microsoft.com/en-us/dotnet/api/microsoft.semantickernel.azureopenaikernelbuilderextensions.addazureopenaichatcompletion?view=semantic-kernel-dotnet#microsoft-semantickernel-azureopenaikernelbuilderextensions-addazureopenaichatcompletion(microsoft-semantickernel-ikernelbuilder-system-string-system-string-system-string-system-string-system-net-http-httpclient-system-string))) in the latest version of Semantic Kernel (the Semantic Kernel package is updated when you run the `dotnet add` commands in one of the previous steps), the signature of the `AddAzureOpenAIChatCompletion` method has deploymentName, endpoint and key as arguments, in that order, but in the above code there are key, endpoint and deploymentName which generates an error when calling it.