### PR TITLE
Lab02 some typo fixes

### DIFF
--- a/Instructions/Labs/02-run-prompts.md
+++ b/Instructions/Labs/02-run-prompts.md
@@ -98,7 +98,7 @@ Now that you deployed a model, you're ready to create a Semantic Kernel client a
 
     ```
     dotnet add package Microsoft.SemanticKernel
-    dotnet add package Microsoft.SemanticKernel.PromptTemplates.Handlebars;
+    dotnet add package Microsoft.SemanticKernel.PromptTemplates.Handlebars
     ```
 
 1. Enter the following command to edit the configuration file that has been provided:

--- a/Instructions/Labs/02-run-prompts.md
+++ b/Instructions/Labs/02-run-prompts.md
@@ -256,7 +256,7 @@ Now you create a prompt template that instructs the AI to suggest suitable roles
 
     **Python**
     ```python
-    # Render the Semanitc Kernel prompt with arguments
+    # Render the Semantic Kernel prompt with arguments
     sk_rendered_prompt = await sk_prompt_template.render(
         kernel,
         KernelArguments(
@@ -268,7 +268,7 @@ Now you create a prompt template that instructs the AI to suggest suitable roles
 
     **C#**
     ```c#
-    // Render the Semanitc Kernel prompt with arguments
+    // Render the Semantic Kernel prompt with arguments
     var skRenderedPrompt = await skPromptTemplate.RenderAsync(
         kernel,
         new KernelArguments

--- a/Labfiles/02-run-prompts/C-sharp/Program.cs
+++ b/Labfiles/02-run-prompts/C-sharp/Program.cs
@@ -23,7 +23,7 @@ string deploymentName = config["DEPLOYMENT_NAME"]!;
 // Create a semantic kernel prompt template
 
 
-// Render the prompt with arguments
+// Render the Semantic Kernel prompt with arguments
 
 
 // Add the Semanitc Kernel prompt to the chat history and get the reply


### PR DESCRIPTION
This pull request includes minor corrections to documentation and code comments related to the Semantic Kernel prompt templates.

Documentation corrections:

* [`Instructions/Labs/02-run-prompts.md`](diffhunk://#diff-f464360e1a3d9cfaec9d7160addefd8b60d875480dfb5c7f56789623e4a8955eL101-R101): Fixed a typo in the package installation instructions by removing an unnecessary semicolon.
* [`Instructions/Labs/02-run-prompts.md`](diffhunk://#diff-f464360e1a3d9cfaec9d7160addefd8b60d875480dfb5c7f56789623e4a8955eL259-R259): Corrected the spelling of "Semantic Kernel" in Python and C# code snippets. [[1]](diffhunk://#diff-f464360e1a3d9cfaec9d7160addefd8b60d875480dfb5c7f56789623e4a8955eL259-R259) [[2]](diffhunk://#diff-f464360e1a3d9cfaec9d7160addefd8b60d875480dfb5c7f56789623e4a8955eL271-R271)

Code comment corrections:

* [`Labfiles/02-run-prompts/C-sharp/Program.cs`](diffhunk://#diff-527a64c0d472d1235852967140b66d46d51081ce0bbffcc55879658922dbaa4fL26-R26): Updated a comment to correctly refer to "Semantic Kernel" instead of "Semanitc Kernel."