### PR TITLE
LAB03-Advertise selected functions-STEP01 : The variable name in the FunctionChoiceBehavior is wrong

### DIFF
--- a/Instructions/Labs/03-create-plugins.md
+++ b/Instructions/Labs/03-create-plugins.md
@@ -359,7 +359,7 @@ Now you configure your kernel so that only selected functions are available to a
 
     PromptExecutionSettings openAIPromptExecutionSettings = new() 
     {
-        FunctionChoiceBehavior = FunctionChoiceBehavior.Required(functions: [search_flights]) 
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Required(functions: [searchFlights]) 
     };
     ```
 


### PR DESCRIPTION
This pull request includes a minor change to the `Instructions/Labs/03-create-plugins.md` file. The change updates the function name from `search_flights` to `searchFlights` for consistency with naming conventions.