### PR TITLE
LAB04 - Change the comment of filter class definition to match the lab instructions

### DIFF
--- a/Labfiles/04-apply-function-filters/C-sharp/Program.cs
+++ b/Labfiles/04-apply-function-filters/C-sharp/Program.cs
@@ -58,7 +58,7 @@ void AddUserMessage(string msg)
     history.AddUserMessage(msg);
 }
 
-// Implement the function filter interface
+// Create the function filer class
 public class PermissionFilter
 {
 


### PR DESCRIPTION
This pull request includes a small change to the `Program.cs` file. The change updates a comment to clarify that the `PermissionFilter` class is being created rather than implementing an interface.