### PR TITLE
All Labs: Update target framework to .NET 9.0 across all project files

### DIFF
--- a/Labfiles/01-build-your-kernel/C-sharp/Kernel.csproj
+++ b/Labfiles/01-build-your-kernel/C-sharp/Kernel.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Labfiles/02-run-prompts/C-sharp/Prompts.csproj
+++ b/Labfiles/02-run-prompts/C-sharp/Prompts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Labfiles/03-create-plugins/C-sharp/Plugins.csproj
+++ b/Labfiles/03-create-plugins/C-sharp/Plugins.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Labfiles/04-apply-function-filters/C-sharp/Filters.csproj
+++ b/Labfiles/04-apply-function-filters/C-sharp/Filters.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Labfiles/05-ai-assistant/c-sharp/new-sk-labs.csproj
+++ b/Labfiles/05-ai-assistant/c-sharp/new-sk-labs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>new_sk_labs</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
This pull request updates the target framework for multiple C# project files to use `.NET 9.0`, ensuring compatibility with the latest features and improvements in the framework.

### Target Framework Updates:
* Updated the `TargetFramework` from `net8.0` to `net9.0` in the following project files:
  - `Labfiles/01-build-your-kernel/C-sharp/Kernel.csproj`
  - `Labfiles/02-run-prompts/C-sharp/Prompts.csproj`
  - `Labfiles/03-create-plugins/C-sharp/Plugins.csproj`
  - `Labfiles/04-apply-function-filters/C-sharp/Filters.csproj`
  - `Labfiles/05-ai-assistant/c-sharp/new-sk-labs.csproj`

It should be solve the Issue #16 