### PR TITLE
Fixed typo in 03-create-plugins.md

### DIFF
--- a/Instructions/Labs/03-create-plugins.md
+++ b/Instructions/Labs/03-create-plugins.md
@@ -359,7 +359,7 @@ Now you configure your kernel so that only selected functions are available to a
 
     PromptExecutionSettings openAIPromptExecutionSettings = new() 
     {
-        FunctionChoiceBehavior = FunctionChoiceBehavior.Required(functions: [search_flights]) 
+        FunctionChoiceBehavior = FunctionChoiceBehavior.Required(functions: [searchFlights]) 
     };
     ```
 


### PR DESCRIPTION
Fixed c-sharp typo while following the final instructions to narrow the function choice behavior